### PR TITLE
Group Dependabot Dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
+    groups:
+      github-action-dependencies:
+        patterns:
+          - "*"
 
   # Maintain dependencies for Python (Works recursively in application directories)
   - package-ecosystem: "pip"
@@ -13,4 +17,7 @@ updates:
     schedule:
       interval: "monthly"
     target-branch: "main"
-    versioning-strategy: increase-if-necessary
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Group Dependabot dependencies into groups for easier merging. Groups are currently set for Python and GitHub Actions.