### PR TITLE
Upgrade Python to 3.13 and update dependencies

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -47,10 +47,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install Python Development Requirements
         run: make development-install
       - name: Python Format Check
@@ -67,7 +67,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.1.3
+        uses: UmbrellaDocs/action-linkspector@v1.2.2
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configs/.linkspector.yml

--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -19,10 +19,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Python Development Requirements
         run: make development-install
       - name: Install Production Dependencies
@@ -32,9 +32,10 @@ jobs:
         run: make unit-test
         working-directory: ./applications/${{ matrix.folder }}
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.1
         with:
           name: ${{ matrix.folder }}_coverage
+          include-hidden-files: true
           path: ./applications/${{ matrix.folder }}/.coverage
           retention-days: 1
   sonarcloud:
@@ -48,19 +49,19 @@ jobs:
           fetch-depth: 0
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Python Development Requirements
         run: make development-install
       - name: Combine Coverage Reports
         run: make coverage-combine-and-report
-      - uses: sonarsource/sonarcloud-github-action@v3.0.0
+      - uses: sonarsource/sonarcloud-github-action@v3.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           projectBaseDir: .
           args: |
-            -Dsonar.sources=applications,containers,deployment,requests -Dsonar.organization=jackplowman -Dsonar.projectKey=JackPlowman_python-playground -Dsonar.coverage.exclusions=**/tests/**,containers,deployment,requests -Dsonar.python.coverage.reportPaths=coverage.xml -Dsonar.python.version=3.12 -Dsonar.exclusions=applications/**/manage.py,applications/**/tests/**,applications/**/api/**,applications/**/migrations/** -Dsonar.cpd.exclusions=applications/**/api/**
+            -Dsonar.sources=applications,containers,deployment,requests -Dsonar.organization=jackplowman -Dsonar.projectKey=JackPlowman_python-playground -Dsonar.coverage.exclusions=**/tests/**,containers,deployment,requests -Dsonar.python.coverage.reportPaths=coverage.xml -Dsonar.python.version=3.13 -Dsonar.exclusions=applications/**/manage.py,applications/**/tests/**,applications/**/api/**,applications/**/migrations/** -Dsonar.cpd.exclusions=applications/**/api/**

--- a/applications/django_graphql/requirements.txt
+++ b/applications/django_graphql/requirements.txt
@@ -1,4 +1,4 @@
-Django == 5.1
+Django == 5.1.2
 graphene == 3.3.0
 graphene-django == 3.2.2
 gunicorn == 23.0.0

--- a/applications/django_rest/requirements.txt
+++ b/applications/django_rest/requirements.txt
@@ -1,3 +1,3 @@
-Django == 5.1
+Django == 5.1.2
 djangorestframework == 3.15.2
 gunicorn == 23.0.0

--- a/applications/requirements-dev.txt
+++ b/applications/requirements-dev.txt
@@ -1,6 +1,6 @@
 coverage == 7.6.1
-pytest == 8.3.2
+pytest == 8.3.3
 pytest-cov == 5.0.0
-pytest-django == 4.8.0
-ruff == 0.6.2
-SQLFluff == 3.1.1
+pytest-django == 4.9.0
+ruff == 0.6.9
+SQLFluff == 3.2.2

--- a/containers/docker/django_graphql/Dockerfile
+++ b/containers/docker/django_graphql/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 RUN apt-get update
 

--- a/containers/docker/django_rest/Dockerfile
+++ b/containers/docker/django_rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 RUN apt-get update
 

--- a/containers/podman/django_graphql/Containerfile
+++ b/containers/podman/django_graphql/Containerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 RUN apt-get update
 

--- a/containers/podman/django_rest/Containerfile
+++ b/containers/podman/django_rest/Containerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 RUN apt-get update
 

--- a/python-playground.code-workspace
+++ b/python-playground.code-workspace
@@ -19,12 +19,12 @@
     "files.trimTrailingWhitespace": true,
     "files.watcherExclude": {
       "**/.git": true,
-      "**/tmp": true
+      "**/tmp": true,
     },
     "python.terminal.activateEnvironment": false,
     "search.exclude": {
       "**/.git": true,
-      "**/tmp": true
+      "**/tmp": true,
     },
     "terminal.integrated.fontFamily": "Hack Nerd Font",
     "window.title": "${activeEditorMedium}${separator}${rootName}${separator}${rootPath}",
@@ -34,27 +34,27 @@
     "[dockerfile]": {
       "editor.formatOnSave": false,
       "editor.insertSpaces": true,
-      "editor.tabSize": 4
+      "editor.tabSize": 4,
     },
     "[json]": {
       "editor.insertSpaces": true,
-      "editor.tabSize": 2
+      "editor.tabSize": 2,
     },
     "[python]": {
       "editor.tabSize": 4,
-      "editor.insertSpaces": true
+      "editor.insertSpaces": true,
     },
     "[makefile]": {
       "editor.insertSpaces": false,
-      "editor.tabSize": 2
+      "editor.tabSize": 2,
     },
     "[markdown]": {
       "editor.insertSpaces": true,
-      "editor.tabSize": 2
+      "editor.tabSize": 2,
     },
     "[yaml]": {
       "editor.insertSpaces": true,
-      "editor.tabSize": 2
+      "editor.tabSize": 2,
     },
     "yaml.customTags": [
       "!And",
@@ -83,14 +83,14 @@
       "!Select",
       "!Select sequence",
       "!Split",
-      "!Split sequence"
+      "!Split sequence",
     ],
     "workbench.colorTheme": "Solarized Dark",
-    "vale.valeCLI.config": "${workspaceFolder}/.vale.ini"
+    "vale.valeCLI.config": "${workspaceFolder}/.vale.ini",
   },
   "folders": [
     {
-      "path": "."
-    }
-  ]
+      "path": ".",
+    },
+  ],
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Python version from 3.12 to 3.13 across various files and workflows. It also upgrades several dependencies to their latest versions:

- Django updated to 5.1.2 in both django_graphql and django_rest applications
- pytest upgraded to 8.3.3
- pytest-django bumped to 4.9.0
- ruff updated to 0.6.9
- SQLFluff upgraded to 3.2.2

The GitHub Actions workflows have been modified to use Python 3.13, and the SonarCloud action has been updated to v3.1.0. The Markdown link checker action has also been upgraded to v1.2.2.

Docker and Podman container files now use Python 3.13-slim as the base image.

Additionally, minor formatting changes have been made to the VSCode workspace settings file, including the addition of trailing commas for consistency.

These updates aim to keep the project current with the latest Python version and package releases, potentially improving performance and security.