### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/check-repository-visualisation.yml
+++ b/.github/workflows/check-repository-visualisation.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Get changed files in the applications folder
         id: changed-files-specific
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v45.0.3
         with:
           files: applications/**
           files_ignore: |
@@ -21,7 +21,7 @@ jobs:
             applications/*/requirements.txt
       - name: Check for Required Labels
         if: ${{ !contains( github.event.pull_request.labels.*.name, 'dependencies') && steps.changed-files-specific.outputs.any_changed == 'true' }}
-        uses: mheap/github-action-required-labels@v5
+        uses: mheap/github-action-required-labels@v5.4.1
         with:
           mode: exactly
           count: 1

--- a/.github/workflows/code-build.yml
+++ b/.github/workflows/code-build.yml
@@ -17,7 +17,7 @@ jobs:
         application: [django_rest, django_graphql]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: Build Image

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: Lint Code Base
@@ -44,11 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: "3.13"
       - name: Install Python Development Requirements
@@ -63,11 +63,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.2.2
+        uses: UmbrellaDocs/action-linkspector@v1.2.4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configs/.linkspector.yml

--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -16,11 +16,11 @@ jobs:
         folder: [django_rest, django_graphql, flask_rest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: "3.13"
       - name: Python Development Requirements
@@ -44,13 +44,13 @@ jobs:
     needs: [unit-test]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.8
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: "3.13"
       - name: Python Development Requirements

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,11 +17,11 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v3.27.0
         with:
           languages: python
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v3.27.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v4.4.0

--- a/.github/workflows/repository-visualisation.yml
+++ b/.github/workflows/repository-visualisation.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ github.event.label.name == 'awaiting-repository-visualisation' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -22,11 +22,12 @@ jobs:
           excluded_paths: .github
           output_file: repository-visualisation.svg
       - name: Remove awaiting label
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
           labels: awaiting-repository-visualisation
           github_token: ${{ secrets.GH_TOKEN }}
       - name: Add completed label
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@v1.1.0
         with:
           labels: updated-repository-visualisation
+          github_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This change updates the versions of various GitHub Actions used in the repository's workflows. Specifically:

- `tj-actions/changed-files` updated to v45.0.3
- `mheap/github-action-required-labels` updated to v5.4.1
- `actions/checkout` updated to v4.2.2
- `actions/setup-python` updated to v5.3.0
- `UmbrellaDocs/action-linkspector` updated to v1.2.4
- `actions/download-artifact` updated to v4.1.8
- `github/codeql-action/init` and `github/codeql-action/analyze` updated to v3.27.0
- `actions/dependency-review-action` updated to v4.4.0
- `actions-ecosystem/action-remove-labels` updated to v1.3.0
- `actions-ecosystem/action-add-labels` updated to v1.1.0

Additionally, a `github_token` parameter has been added to the "Add completed label" step in the repository-visualisation workflow.

These updates ensure the repository is using the latest versions of these actions, which may include bug fixes, performance improvements, or new features.